### PR TITLE
Fix incorrect assumption about username based on email

### DIFF
--- a/classes/utility.php
+++ b/classes/utility.php
@@ -59,11 +59,6 @@ class utility {
             $params['username'] = $data['username'];
         }
 
-        // This setting means the email address is the username.
-        if ($CFG->createuserwithemail) {
-            $params['username'] = $data['email'];
-        }
-
         return $DB->get_record('user', $params, '*');
     }
 

--- a/unsuspend.php
+++ b/unsuspend.php
@@ -41,6 +41,7 @@ $PAGE->set_url($baseurl);
 $PAGE->set_pagelayout('login');
 $PAGE->set_title(get_string('title_unsuspend', 'auth_enrolkey'));
 $PAGE->set_heading(get_string('heading_unsuspend', 'auth_enrolkey'));
+$PAGE->set_context($context);
 $output = $PAGE->get_renderer('auth_enrolkey');
 
 $form = new unsuspend_form($baseurl);


### PR DESCRIPTION
The code incorrectly assumed that if a cfg control was set, that username always equals email. That is not the case for manually created users. This shouldn't cause any issues, as the password is checked against the grabbed account, so any accounts grabbed here ARE checked afterward