### PR TITLE
Support 4.1 and 4.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,9 +29,9 @@ https://moodle.org/plugins/block_enrolkey
 Branches
 --------
 
-| Moodle version        | Branch      | PHP   |
-| --------------------- | ----------- | ----- |
-| Moodle 3.5 to 3.11    | master      | 7.1+  |
+| Moodle version    | Branch      | PHP   |
+|-------------------| ----------- | ----- |
+| Moodle 3.5 to 4.5 | master      | 7.1+  |
 
 Installation
 ------------
@@ -66,7 +66,9 @@ Admin Usage
 
 Enable a new Self enrolment method in the course required.
 
-`Course administration > Users > Enrolment methods > Add method > Self enrolment`
+Moodle 3.5 to 3.11, `Course administration > Users > Enrolment methods > Add method > Self enrolment`
+
+Moodle 4.0+, `Participants > Enrolments > Enrolment methods > Add method > Self enrolment`
 
 The Enrolment key field that is visible will be used for the automatic enrolment on signup.
 

--- a/auth.php
+++ b/auth.php
@@ -172,6 +172,7 @@ class auth_plugin_enrolkey extends auth_plugin_base {
             // Access to course, but confirmation required before next login attempt.
             $user->confirmed = 0;
         }
+        $user->lastip = getremoteaddr();
         $user->id = user_create_user($user, false, false);
 
         // Save any custom profile field information.
@@ -179,11 +180,10 @@ class auth_plugin_enrolkey extends auth_plugin_base {
 
         // Trigger event.
         \core\event\user_created::create_from_userid($user->id)->trigger();
-
         if ($notify) {
             if (!send_confirmation_email($user)) {
                 // TODO make this more resilient? Email shouldn't be critical here.
-                print_error('noemail', 'auth_enrolkey');
+                throw new \moodle_exception('noemail', 'auth_enrolkey');
             }
         }
 

--- a/version.php
+++ b/version.php
@@ -29,4 +29,4 @@ $plugin->release   = 2022011200;        // Match release exactly to version.
 $plugin->requires  = 2014051200;        // Requires this Moodle version (2.7+).
 $plugin->component = 'auth_enrolkey';      // Full name of the plugin (used for diagnostics).
 $plugin->maturity  = MATURITY_STABLE;
-$plugin->supported = [35, 311];            // A range of branch numbers of supported moodle versions.
+$plugin->supported = [35, 405];            // A range of branch numbers of supported moodle versions.


### PR DESCRIPTION
Tested with 4.1 and 4.5.

There are 2 issues.

- `Undefined property: stdClass::$lastip`  from `update_user_login_times()` in `lib/moodlelib.php`

- The function `print_error` is removed from Moodle 4.5.

Also update the supported versions in this plugin.