### PR TITLE
Update profile field and cohort in enrol_user

### DIFF
--- a/auth.php
+++ b/auth.php
@@ -26,6 +26,8 @@ defined('MOODLE_INTERNAL') || die;
 
 require_once($CFG->libdir . '/authlib.php');
 
+use auth_enrolkey\utility;
+
 // If totara cohort lib exists, import it.
 if (file_exists($CFG->dirroot . '/totara/cohort/lib.php')) {
     require_once($CFG->dirroot . '/totara/cohort/lib.php');
@@ -251,21 +253,8 @@ class auth_plugin_enrolkey extends auth_plugin_base {
             }
         }
 
-        if ($availableenrolids) {
-            // New Enrolkey hook, will force/add user profile fields user based on the enrolkey used.
-            \auth_enrolkey\persistent\enrolkey_profile_mapping::add_fields_during_signup($USER, $availableenrolids);
-
-            // New Enrolkey hook, will assign and enrol this user to corhots based on the enrolkey used.
-            \auth_enrolkey\persistent\enrolkey_cohort_mapping::add_cohorts_during_signup($USER, $availableenrolids);
-
-            // At this point signup and enrolment is finished.
-            // If enabled, run a cohort sync to force dynamic cohorts to update.
-            if (get_config('auth_enrolkey', 'totaracohortsync') &&
-                function_exists('totara_cohort_check_and_update_dynamic_cohort_members')) {
-                $trace = new \null_progress_trace();
-                // This may be a perfomance hog.
-                totara_cohort_check_and_update_dynamic_cohort_members(null, $trace);
-            }
+        if (!empty($availableenrolids)) {
+            utility::update_user($USER, $availableenrolids);
         }
 
         return [$availableenrolids, $errors];

--- a/auth.php
+++ b/auth.php
@@ -202,21 +202,6 @@ class auth_plugin_enrolkey extends auth_plugin_base {
             return;
         }
 
-        // New Enrolkey hook, will force/add user profile fields user based on the enrolkey used.
-        \auth_enrolkey\persistent\enrolkey_profile_mapping::add_fields_during_signup($user, $availableenrolids);
-
-        // New Enrolkey hook, will assign and enrol this user to corhots based on the enrolkey used.
-        \auth_enrolkey\persistent\enrolkey_cohort_mapping::add_cohorts_during_signup($user, $availableenrolids);
-
-        // At this point signup and enrolment is finished.
-        // If enabled, run a cohort sync to force dynamic cohorts to update.
-        if (get_config('auth_enrolkey', 'totaracohortsync') &&
-            function_exists('totara_cohort_check_and_update_dynamic_cohort_members')) {
-            $trace = new \null_progress_trace();
-            // This may be a perfomance hog.
-            totara_cohort_check_and_update_dynamic_cohort_members(null, $trace);
-        }
-
         if (!empty($availableenrolids) && $user->confirmed === 0 && $user->policyagreed === 0) {
             $this->email_confirmation($user->email);
         }
@@ -247,7 +232,7 @@ class auth_plugin_enrolkey extends auth_plugin_base {
      * @return array
      */
     public function enrol_user(string $enrolkey, bool $notify = true) : array {
-        global $DB;
+        global $DB, $USER;
 
         /** @var enrol_self_plugin $enrol */
         $enrol = enrol_get_plugin('self');
@@ -265,6 +250,24 @@ class auth_plugin_enrolkey extends auth_plugin_base {
                 $errors[$enrolplugin->courseid] = $enrol->can_self_enrol($enrolplugin);
             }
         }
+
+        if ($availableenrolids) {
+            // New Enrolkey hook, will force/add user profile fields user based on the enrolkey used.
+            \auth_enrolkey\persistent\enrolkey_profile_mapping::add_fields_during_signup($USER, $availableenrolids);
+
+            // New Enrolkey hook, will assign and enrol this user to corhots based on the enrolkey used.
+            \auth_enrolkey\persistent\enrolkey_cohort_mapping::add_cohorts_during_signup($USER, $availableenrolids);
+
+            // At this point signup and enrolment is finished.
+            // If enabled, run a cohort sync to force dynamic cohorts to update.
+            if (get_config('auth_enrolkey', 'totaracohortsync') &&
+                function_exists('totara_cohort_check_and_update_dynamic_cohort_members')) {
+                $trace = new \null_progress_trace();
+                // This may be a perfomance hog.
+                totara_cohort_check_and_update_dynamic_cohort_members(null, $trace);
+            }
+        }
+
         return [$availableenrolids, $errors];
     }
 

--- a/classes/persistent/enrolkey_cohort_mapping.php
+++ b/classes/persistent/enrolkey_cohort_mapping.php
@@ -73,7 +73,7 @@ class enrolkey_cohort_mapping extends persistent {
     /**
      * During auth.php->user_signup, this adds the user to the associated cohorts.
      *
-     * @param stdClass $user
+     * @param \stdClass $user
      * @param array $availableenrolids
      */
     public static function add_cohorts_during_signup($user, $availableenrolids) {

--- a/classes/persistent/enrolkey_profile_mapping.php
+++ b/classes/persistent/enrolkey_profile_mapping.php
@@ -73,7 +73,7 @@ class enrolkey_profile_mapping extends persistent {
     /**
      * During auth.php->user_signup, this adds the forced user profile fields.
      *
-     * @param stdClass $user
+     * @param \stdClass $user
      * @param array $availableenrolids
      */
     public static function add_fields_during_signup($user, $availableenrolids) {

--- a/classes/utility.php
+++ b/classes/utility.php
@@ -200,4 +200,26 @@ class utility {
 
         return true;
     }
+
+    /**
+     * Updates user profile and cohort according to the set enrolkey mappings.
+     *
+     * @param \stdClass $user the user to update
+     * @param array $availableenrolids the enrol ids for the enrolkey used
+     */
+    public static function update_user($user, $availableenrolids) {
+        // Update user profile fields based on the enrolkey used.
+        \auth_enrolkey\persistent\enrolkey_profile_mapping::add_fields_during_signup($user, $availableenrolids);
+
+        // Assign this user to corhots based on the enrolkey used.
+        \auth_enrolkey\persistent\enrolkey_cohort_mapping::add_cohorts_during_signup($user, $availableenrolids);
+
+        // If enabled, run a cohort sync to force dynamic cohorts to update.
+        if (get_config('auth_enrolkey', 'totaracohortsync') &&
+            function_exists('totara_cohort_check_and_update_dynamic_cohort_members')) {
+            $trace = new \null_progress_trace();
+            // This may be a perfomance hog.
+            totara_cohort_check_and_update_dynamic_cohort_members(null, $trace);
+        }
+    }
 }

--- a/unsuspend.php
+++ b/unsuspend.php
@@ -77,6 +77,16 @@ if ($form->is_cancelled()) {
                 if (authenticate_user_login($user->username, $data->password)) {
                     \auth_enrolkey\persistent\enrolkey_profile_mapping::add_fields_during_signup($user, $availableenrolids);
                     \auth_enrolkey\persistent\enrolkey_cohort_mapping::add_cohorts_during_signup($user, $availableenrolids);
+
+                    // At this point signup and enrolment is finished.
+                    // If enabled, run a cohort sync to force dynamic cohorts to update.
+                    if (get_config('auth_enrolkey', 'totaracohortsync') &&
+                        function_exists('totara_cohort_check_and_update_dynamic_cohort_members')) {
+                        $trace = new \null_progress_trace();
+                        // This may be a perfomance hog.
+                        totara_cohort_check_and_update_dynamic_cohort_members(null, $trace);
+                    }
+
                     \auth_enrolkey\persistent\enrolkey_redirect_mapping::redirect_during_signup($availableenrolids);
 
                     // Default redirect.


### PR DESCRIPTION
Some other plugins like block_enrolkey only call enrol_user so the profile fields and cohort are not updated. These should always be updated when using an enrol key.

Also after unsuspending a user dynamic cohorts were not updated for Totara, so added that piece too for consistency.

Testing instructions;
1. As an admin;
2. Have both auth_enrolkey and block_enrolkey installed
3. Set up an enrol key for a self enrol instance in a course
4. Add the enrol key block to the dashboard
5. Go to Site administration > Plugins > Authentication > Enrolment key based self-registration > Manage enrolkey cohort rules
6. Add at least one cohort and profile field for the enrol key
7. As a student;
8. Login and go to the dashboard
9. Enter the enrol key in the block
10. You should receive a message saying you were enrolled into the course
11. As an admin;
12. Check the student was added to the cohort and the profile field was updated correctly