### PR TITLE
issue 37 - setting emailconfirmation on "no" = no mail

### DIFF
--- a/auth.php
+++ b/auth.php
@@ -185,7 +185,7 @@ class auth_plugin_enrolkey extends auth_plugin_base {
         if ($notify && $emailconfirmation !== '0') {
             if (!send_confirmation_email($user)) {
                 // TODO make this more resilient? Email shouldn't be critical here.
-                print_error('noemail', 'auth_enrolkey');
+                throw new \moodle_exception('noemail', 'auth_enrolkey');
             }
         }
 

--- a/auth.php
+++ b/auth.php
@@ -182,10 +182,10 @@ class auth_plugin_enrolkey extends auth_plugin_base {
 
         // Trigger event.
         \core\event\user_created::create_from_userid($user->id)->trigger();
-        if ($notify) {
+        if ($notify && $emailconfirmation !== '0') {
             if (!send_confirmation_email($user)) {
                 // TODO make this more resilient? Email shouldn't be critical here.
-                throw new \moodle_exception('noemail', 'auth_enrolkey');
+                print_error('noemail', 'auth_enrolkey');
             }
         }
 


### PR DESCRIPTION
Resolve the issue 37. 
When the setting "auth_enrolkey | emailconfirmation" is on 'no' do not send the confirmation email.
Add a verification of the emailconfirmation setting status before sending the confirmation mail